### PR TITLE
Improve header toggle accessibility

### DIFF
--- a/src/components/HeaderComponents/Header.tsx
+++ b/src/components/HeaderComponents/Header.tsx
@@ -24,11 +24,19 @@ export const Header = () => {
         {
           width < 768 ?
           <>
-          <svg viewBox="0 0 100 80" width="40" height="40" xmlns="http://www.w3.org/2000/svg" onClick={handleClick}>
-            <rect width="100" height="10" fill="#ea8f1d"></rect>  
-            <rect y="30" width="100" height="10" fill="#ea8f1d"></rect>
-            <rect y="60" width="100" height="10" fill="#ea8f1d"></rect>
-          </svg>
+          <button
+            type="button"
+            aria-label="Abrir menú"
+            aria-expanded={isOpen}
+            onClick={handleClick}
+            className="header-toggle"
+          >
+            <svg viewBox="0 0 100 80" width="40" height="40" xmlns="http://www.w3.org/2000/svg">
+              <rect width="100" height="10" fill="#ea8f1d" />
+              <rect y="30" width="100" height="10" fill="#ea8f1d" />
+              <rect y="60" width="100" height="10" fill="#ea8f1d" />
+            </svg>
+          </button>
           <MobileComponent isOpen={isOpen} setIsOpen={setIsOpen}/>
           </>
             :

--- a/src/styles/header.css
+++ b/src/styles/header.css
@@ -124,3 +124,10 @@ header .mobile-navbar ul{
     padding-top: 14px;
     padding-bottom: 14px;
 }
+
+header .header-toggle{
+    background: none;
+    border: none;
+    padding: 0;
+    cursor: pointer;
+}


### PR DESCRIPTION
## Summary
- use a `<button>` for the mobile menu toggle instead of a plain `<svg>`
- expose `aria-label` and `aria-expanded` on the toggle button
- add styling for the new toggle button

## Testing
- `npm run lint` *(fails: ESLint couldn't find config)*
- `npm test` *(fails: missing test script)*

------
https://chatgpt.com/codex/tasks/task_e_68794672e6c083289f7f846b664e1ff2